### PR TITLE
👷 Unit tests CI workflow for packages/strategies

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,54 @@
+name: Unit Tests
+
+env:
+  FOUNDRY_PROFILE: "ci"
+
+# This CI workflow is responsible of running the tests.
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+      # temporary until the merge of onlyboost-v2
+      - feat/onlyboost-v2
+  push:
+    branches:
+      - main
+      # temporary until the merge of onlyboost-v2
+      - feat/onlyboost-v2
+
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          run_install: false
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Show the Foundry config
+        working-directory: packages/strategies
+        run: forge config
+
+      - name: Run tests
+        working-directory: packages/strategies
+        run: forge test


### PR DESCRIPTION
Automatically run unit tests on pushes and pull requests targetting the `main` and `feat/onlyboost-v2` branches (temporary).