### PR TITLE
🧪🐛 bug: undetected overflow in `integral` variable

### DIFF
--- a/packages/strategies/src/Accountant.sol
+++ b/packages/strategies/src/Accountant.sol
@@ -312,6 +312,14 @@ contract Accountant is ReentrancyGuardTransient, Ownable2Step {
         _vault.supplyAndIntegralSlot = (supply & StorageMasks.SUPPLY) | ((integral << 128) & StorageMasks.INTEGRAL);
     }
 
+    // REMOVE ME ASAP
+    error OverflowIntegral(
+        uint256 scalingFactor,
+        uint256 overflowedValue,
+        uint128 overflowedValueCastedToUint128Unsafely,
+        uint256 uint128Max
+    );
+
     /// @dev Updates account state during operations.
     /// @param vault The vault address.
     /// @param account The account to update.
@@ -336,6 +344,12 @@ contract Accountant is ReentrancyGuardTransient, Ownable2Step {
 
         // Update balance
         balance = isDecrease ? balance - amount : balance + amount;
+
+        // REMOVE ME ASAP -- TESTING PURPOSE
+        require(
+            currentIntegral < type(uint128).max,
+            OverflowIntegral(SCALING_FACTOR, currentIntegral, uint128(currentIntegral), type(uint128).max)
+        );
 
         // Pack and store updated values
         _account.balanceAndIntegralSlot =

--- a/packages/strategies/test/unit/Accountant.t.sol
+++ b/packages/strategies/test/unit/Accountant.t.sol
@@ -103,6 +103,11 @@ contract AccountantTest is BaseTest {
         assertEq(accountant.totalSupply(address(this)), amount);
     }
 
+    /**
+     * forge-config: default.fuzz.runs = 4096
+     * forge-config: default.fuzz.dictionary_weight = 100
+     * forge-config: default.fuzz.show-logs = true
+     */
     function test_checkpoint_with_pending_rewards(uint128 amount, uint128 rewards) public {
         // Ensure reasonable bounds for testing
         vm.assume(amount >= 1e18 && amount <= 1e24);


### PR DESCRIPTION
--- THIS PR IS NOT INTENDED TO BE MERGED

This commit introduces a minimal reproduction demonstrating an undetected overflow in the `integral` variable due to the current scaling factor.

The test `test_checkpoint_with_pending_rewards` evaluates various valid amounts and reward values up to `1e24`. However, neither the test nor the function verifies whether the stored `integral` value remains coherent.

The tested function modifies `integral`, which is stored as a `uint128`, while arithmetic operations are performed using `uint256`. The result is unsafely cast back to `uint128` without ensuring it fits within the valid `uint128` range. Consequently, values exceeding `2^128 - 1` overflow silently, leading to incorrect stored values.

With the current scaling factor (RAY — `1e27`), the test consistently fails. It continues to fail for high but acceptable values until we reduce the scaling factor to ~`1e20`, which provides enough margin for expected arithmetic.

Given the target precision, we should probably consider changing the scaling factor to `1e18` (WAD) or accepting higher gas consumption by storing `integral` as `uint256`.

--- THIS PR IS NOT INTENDED TO BE MERGED