### PR TITLE
ci: add test coverage workflows

### DIFF
--- a/.github/workflows/lockers_coverage.yml
+++ b/.github/workflows/lockers_coverage.yml
@@ -1,0 +1,91 @@
+name: Lockers - Test Coverage
+
+env:
+  FOUNDRY_PROFILE: "ci"
+  VYPER_VERSION: "0.3.10"
+  ALCHEMY_KEY: ${{ secrets.ALCHEMY_KEY }}
+  MNEMONIC: ${{ secrets.MNEMONIC }}
+
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+
+# This CI workflow is responsible of running the test coverage for the lockers package.
+# It is triggered
+# - only when the changes are made to the lockers package or the address-book package
+# - when a PR is opened or when a push is made to the main branch
+# - when a PR is opened or when a push is made to the feat/onlyboost-v2 branch
+# - when the workflow is manually triggered
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "packages/lockers/**"
+      - ".github/workflows/lockers_coverage.yml" # this file
+      - "packages/address-book/**" # dependency
+      - "packages/interfaces/**" # dependency
+    branches:
+      - main
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write # to upload the coverage report as artifact
+      actions: read # to read the artifacts uploaded by another branch
+      pull-requests: write # to post a comment on the PR
+
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          run_install: false
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 21.4
+          cache: "pnpm"
+
+      - name: Install vyper
+        run: pipx install vyper==${{ env.VYPER_VERSION }}
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
+        # the seed changes weekly to avoid burning through RPC allowance
+      - name: Generate the weekly fuzz seed
+        run: >
+          echo "FOUNDRY_FUZZ_SEED=$(
+            echo $(($EPOCHSECONDS - $EPOCHSECONDS % 604800))
+          )" >> $GITHUB_ENV
+
+      - name: Build contracts
+        working-directory: packages/lockers
+        run: forge build
+
+      - name: Run coverage
+        working-directory: packages/lockers
+        run: forge coverage --report lcov --no-match-coverage "(script|test)"
+
+      - name: Setup LCOV
+        uses: hrishikesh-kadam/setup-lcov@v1
+
+      - name: Report code coverage
+        uses: zgosalvez/github-actions-report-lcov@v4
+        with:
+          # the coverage file path is evaluated before the working-directory is set
+          coverage-files: packages/lockers/lcov.info
+          title-prefix: "Lockers | "
+          artifact-name: lockers-code-coverage-report
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          working-directory: packages/lockers
+          update-comment: true
+          # minimum-coverage: 90

--- a/.github/workflows/strategies_coverage.yml
+++ b/.github/workflows/strategies_coverage.yml
@@ -1,0 +1,87 @@
+name: Strategies - Test Coverage
+
+env:
+  FOUNDRY_PROFILE: "ci"
+  ALCHEMY_KEY: ${{ secrets.ALCHEMY_KEY }}
+  MNEMONIC: ${{ secrets.MNEMONIC }}
+
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+
+# This CI workflow is responsible of running the test coverage for the strategies package.
+# It is triggered
+# - only when the changes are made to the strategies package or the address-book package
+# - when a PR is opened or when a push is made to the main branch
+# - when a PR is opened or when a push is made to the feat/onlyboost-v2 branch
+# - when the workflow is manually triggered
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "packages/strategies/**"
+      - ".github/workflows/strategies_coverage.yml" # this file
+      - "packages/address-book/**" # dependency
+      - "packages/interfaces/**" # dependency
+    branches:
+      - main
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write # to upload the coverage report as artifact
+      actions: read # to read the artifacts uploaded by another branch
+      pull-requests: write # to post a comment on the PR
+
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          run_install: false
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 21.4
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
+        # the seed changes weekly to avoid burning through RPC allowance
+      - name: Generate the weekly fuzz seed
+        run: >
+          echo "FOUNDRY_FUZZ_SEED=$(
+            echo $(($EPOCHSECONDS - $EPOCHSECONDS % 604800))
+          )" >> $GITHUB_ENV
+
+      - name: Build contracts
+        working-directory: packages/strategies
+        run: forge build
+
+      - name: Run coverage
+        working-directory: packages/strategies
+        run: forge coverage --report lcov --no-match-coverage "(script|test)"
+
+      - name: Setup LCOV
+        uses: hrishikesh-kadam/setup-lcov@v1
+
+      - name: Report code coverage
+        uses: zgosalvez/github-actions-report-lcov@v4
+        with:
+          # the coverage file path is evaluated before the working-directory is set
+          coverage-files: packages/strategies/lcov.info
+          title-prefix: "Strategies | "
+          artifact-name: strategies-code-coverage-report
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          working-directory: packages/strategies
+          update-comment: true
+          # minimum-coverage: 90


### PR DESCRIPTION
Introduced GitHub Actions workflows for running test coverage on the lockers and strategies packages.
There is no minimum coverage defined for the moment, meaning the CI always succeed. The current workflows are informative only.