### PR TITLE
fix(strategies): emit transfer events on deposit/withdraw

### DIFF
--- a/packages/strategies/src/RewardVault.sol
+++ b/packages/strategies/src/RewardVault.sol
@@ -894,6 +894,8 @@ contract RewardVault is IRewardVault, IERC4626, ERC20 {
             policy: policy,
             referrer: referrer
         });
+
+        emit Transfer(address(0), to, amount);
     }
 
     /// @notice Burns vault shares
@@ -916,6 +918,8 @@ contract RewardVault is IRewardVault, IERC4626, ERC20 {
             pendingRewards: pendingRewards,
             policy: policy
         });
+
+        emit Transfer(from, address(0), amount);
     }
 
     /// @notice Generates the vault's name

--- a/packages/strategies/test/unit/RewardVault/deposit.t.sol
+++ b/packages/strategies/test/unit/RewardVault/deposit.t.sol
@@ -763,6 +763,35 @@ contract RewardVault__deposit is RewardVaultBaseTest {
         deposit_mint_wrapper(OWNER_BALANCE, receiver, address(0));
     }
 
+    function test_EmitsTheTransferEvent(address caller, address receiver)
+        external
+        _cheat_replaceRewardVaultWithRewardVaultHarness
+    {
+        // it emits a transfer event
+
+        _assumeUnlabeledAddress(caller);
+        _assumeUnlabeledAddress(receiver);
+        vm.assume(caller != address(0));
+        vm.assume(receiver != address(0));
+        vm.label({account: caller, newLabel: "caller"});
+        vm.label({account: receiver, newLabel: "receiver"});
+
+        // set the owner balance and approve half the balance
+        uint256 OWNER_BALANCE = 1e18;
+        deal(asset, caller, OWNER_BALANCE);
+        vm.prank(caller);
+        IERC20(asset).approve(address(cloneRewardVault), OWNER_BALANCE);
+
+        // mock the dependencies of the withdraw function
+        _mock_test_dependencies(OWNER_BALANCE, Allocation.MIXED);
+
+        // make the caller deposit the rewards. It should succeed because the allowance is enough
+        vm.prank(caller);
+        vm.expectEmit(true, true, true, true);
+        emit IERC20.Transfer(address(0), receiver, OWNER_BALANCE);
+        deposit_mint_wrapper(OWNER_BALANCE, receiver, address(0));
+    }
+
     function test_ReturnsTheAmountOfAssetsDeposited(address caller, address receiver)
         external
         _cheat_replaceRewardVaultWithRewardVaultHarness

--- a/packages/strategies/test/unit/RewardVault/deposit.tree
+++ b/packages/strategies/test/unit/RewardVault/deposit.tree
@@ -22,4 +22,5 @@ RewardVault__deposit
 ├── it reverts if the deposit to the strategy reverts
 ├── it reverts if one of the ERC20 transfer reverts
 ├── it emits the deposit event
+├── it emits the transfer event
 └── it returns the amount of assets deposited

--- a/packages/strategies/test/unit/RewardVault/withdraw.tree
+++ b/packages/strategies/test/unit/RewardVault/withdraw.tree
@@ -6,5 +6,6 @@ RewardVault__withdraw
 ├── it tells the strategy to withdraw the assets
 ├── it tells the accoutant to burn the tokens
 ├── it transfers the assets to the receiver
-├── it emits the event
+├── it emits the withdraw event
+├── it emits the transfer event
 └── it returns the amount of shares burned


### PR DESCRIPTION
Probably one of our modifications to the vaults broke the transfer events on deposit/withdraw. 
This commit fixes it and include the expected unit tests for it.