### PR TITLE
feat: PreLaunch Locker v2

### DIFF
--- a/packages/lockers/test/unit/LockerPreLaunch/constructor.t.sol
+++ b/packages/lockers/test/unit/LockerPreLaunch/constructor.t.sol
@@ -72,15 +72,6 @@ contract PreLaunchLocker__constructor is PreLaunchLockerTest {
         assertEq(address(locker.gauge()), _gauge);
     }
 
-    function test_SetsTheTimestampToTheCurrentTimestamp(uint96 timestamp) external {
-        // it sets the timestamp to the current timestamp
-
-        vm.warp(timestamp);
-
-        LockerPreLaunch locker = new LockerPreLaunch(makeAddr("token"), address(sdToken), address(gauge), 0);
-        assertEq(locker.timestamp(), timestamp);
-    }
-
     function test_SetsTheStateToIDLE() external {
         // it sets the state to IDLE
 
@@ -114,6 +105,10 @@ contract PreLaunchLocker__constructor is PreLaunchLockerTest {
         LockerPreLaunch locker =
             new LockerPreLaunch(makeAddr("token"), address(sdToken), address(gauge), customForceCancelDelay);
         assertEq(locker.FORCE_CANCEL_DELAY(), customForceCancelDelay);
+    }
+
+    function test_DoesntSetTheTimestamp() external {
+        assertEq(locker.timestamp(), 0);
     }
 
     function test_EmitsTheStateUpdateEvent() external {

--- a/packages/lockers/test/unit/LockerPreLaunch/constructor.tree
+++ b/packages/lockers/test/unit/LockerPreLaunch/constructor.tree
@@ -6,10 +6,10 @@ PreLaunchLocker__constructor
 ├── it sets the token to the given address
 ├── it sets the sdToken to the given address
 ├── it sets the gauge to the given address
-├── it sets the timestamp to the current timestamp
 ├── it sets the state to IDLE
 ├── it sets the governance to the caller
 ├── it sets the default value given no custom force cancel delay
 ├── it sets the custom force cancel delay if provided
+├── it doesn't set the timestamp
 ├── it emits the StateUpdate event
 └── it emits the GovernanceUpdated event

--- a/packages/lockers/test/unit/LockerPreLaunch/deposit.tree
+++ b/packages/lockers/test/unit/LockerPreLaunch/deposit.tree
@@ -15,3 +15,5 @@ PreLaunchLocker__deposit
 │   └── it emits the TokensStaked event
 └── given a receiver when the stake is false
 │   └── it mints sdTokens to the receiver
+├── it sets the timestamp on first deposit
+└── it doesn't modify the timestamp on future deposits

--- a/packages/lockers/test/unit/LockerPreLaunch/forceCancelLocker.t.sol
+++ b/packages/lockers/test/unit/LockerPreLaunch/forceCancelLocker.t.sol
@@ -31,6 +31,12 @@ contract PreLaunchLocker__forceCancelLocker is PreLaunchLockerTest {
     function test_SetsTheStateToCANCELED() external {
         // it sets the state to CANCELED
 
+        // first deposit to trigger the update of timestamp
+        uint256 amount = 1e22;
+        deal(address(token), address(this), amount);
+        token.approve(address(locker), amount);
+        locker.deposit(amount, false);
+
         // fast forward the timestamp by the delay and expect the state to be CANCELED
         vm.warp(block.timestamp + locker.FORCE_CANCEL_DELAY());
         locker.forceCancelLocker();

--- a/packages/lockers/test/unit/LockerPreLaunch/getters.t.sol
+++ b/packages/lockers/test/unit/LockerPreLaunch/getters.t.sol
@@ -38,7 +38,7 @@ contract PreLaunchLocker__getters is PreLaunchLockerTest {
     function test_ExposesTheTimestamp() external view {
         // it exposes the timestamp
 
-        assertNotEq(locker.timestamp(), 0);
+        assertEq(locker.timestamp(), 0);
     }
 
     function skip_test_ExposesTheDepositor(address depositor)


### PR DESCRIPTION
This version sets the force cancel timer at the first deposit instead of at creation
It also emits a new event for tracking the setting of the timeer