### PR TITLE
fix: default enum state value

### DIFF
--- a/packages/lockers/src/DepositorBase.sol
+++ b/packages/lockers/src/DepositorBase.sol
@@ -49,6 +49,7 @@ abstract contract DepositorBase {
     address public futureGovernance;
 
     enum STATE {
+        UNINITIALIZED, // default state at construction
         ACTIVE,
         CANCELED
     }


### PR DESCRIPTION
The first value of an enum is the default value set at construction time. In our case, the depositor was set by default to the active state, which is not what we wanted.